### PR TITLE
Support NewRelic Error Reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Libraries are automatically detected. Supports:
 - [Raygun](https://raygun.io/)
 - [Rollbar](https://rollbar.com/)
 - [Sentry](https://getsentry.com/)
+- [New Relic](https://newrelic.com/)
 
 ```ruby
 begin

--- a/errbase.gemspec
+++ b/errbase.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "opbeat"
   spec.add_development_dependency "exception_notification"
   spec.add_development_dependency "google-cloud-error_reporting"
+  spec.add_development_dependency "newrelic_rpm"
 end

--- a/lib/errbase.rb
+++ b/lib/errbase.rb
@@ -19,6 +19,8 @@ module Errbase
       # don't worry about adding info
       Exceptional.handle(e) if defined?(Exceptional)
 
+      NewRelic::Agent.notice_error(e) if defined?(NewRelic::Agent)
+
       Honeybadger.notify(e, context: info) if defined?(Honeybadger)
 
       # TODO add info

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,4 +12,5 @@ require "bugsnag"
 require "appsignal"
 require "opbeat"
 require "exception_notification"
+require "newrelic_rpm"
 # require "google/cloud/error_reporting" # raises exception when not configured


### PR DESCRIPTION
Added support for NewRelic

~Tweaked the gemspec a bit to create cleaner gems, pollute the load_path less (prematurely) and support the officially supported ruby versions. (You're not running old Ruby, right 😉)~