### PR TITLE
Support sentry-ruby's new interface

### DIFF
--- a/lib/errbase.rb
+++ b/lib/errbase.rb
@@ -27,6 +27,8 @@ module Errbase
       Raygun.track_exception(e, custom_data: info) if defined?(Raygun)
 
       Rollbar.error(e, info) if defined?(Rollbar)
+
+      Sentry.capture_exception(e, extra: info) if defined?(Sentry)
     rescue => e
       $stderr.puts "[errbase] Error reporting exception: #{e.class.name}: #{e.message}"
     end


### PR DESCRIPTION
Recently Sentry rewrote its Ruby SDK and released new `sentry-ruby` gem with [new interfaces](https://github.com/getsentry/sentry-ruby/blob/master/MIGRATION.md#api-changes).